### PR TITLE
Enforce subpath imports for ESLint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
       "types": "./dist/types/providers/index.d.ts"
     },
     "./styles.css": "./dist/js/styles.css",
-    "./eslint-subpath-import": "./dist/js/enforce-subpath-import.js"
+    "./eslint-subpath-import": "./dist/utils/enforce-subpath-import.js"
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/post-build.cjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/lint-rules/base-rule.js
+++ b/scripts/lint-rules/base-rule.js
@@ -1,62 +1,7 @@
 /**
  * ESLint rule for Versaur: enforce sub-path imports for optimal tree-shaking (Flat config compatible)
+ * This file expects a symbolToSubpath object to be defined in the scope before it is loaded.
  */
-
-const symbolToSubpath = {
-  // primitive
-  Button: 'primitive',
-  ButtonFloat: 'primitive',
-  ButtonIcon: 'primitive',
-  Anchor: 'primitive',
-  Avatar: 'primitive',
-  Badge: 'primitive',
-  Brand: 'primitive',
-  Calculator: 'primitive',
-  Calendar: 'primitive',
-  Icon: 'primitive',
-  Snackbar: 'primitive',
-  Table: 'primitive',
-  Text: 'primitive',
-  Tile: 'primitive',
-  Alert: 'primitive',
-  DescriptionList: 'primitive',
-  // overlays
-  Drawer: 'overlays',
-  Modal: 'overlays',
-  Menu: 'overlays',
-  BottomSheet: 'overlays',
-  // navigation
-  Tabs: 'navigation',
-  Breadcrumbs: 'navigation',
-  // layouts
-  AppBar: 'layouts',
-  BottomBar: 'layouts',
-  FormLayout: 'layouts',
-  PageLayout: 'layouts',
-  TopBar: 'layouts',
-  // feedbacks
-  LoadingIndicator: 'feedbacks',
-  ProgressIndicator: 'feedbacks',
-  Skeleton: 'feedbacks',
-  // forms
-  CheckboxInput: 'forms',
-  ChipSingleInput: 'forms',
-  ChipMultipleInput: 'forms',
-  DateSinglePickerInput: 'forms',
-  EmailInput: 'forms',
-  RadioInput: 'forms',
-  SegmentMultipleInput: 'forms',
-  SegmentSingleInput: 'forms',
-  SearchInput: 'forms',
-  SelectInput: 'forms',
-  SwitchInput: 'forms',
-  TextInput: 'forms',
-  TextareaInput: 'forms',
-  TimePickerInput: 'forms',
-  PriceInput: 'forms',
-  // providers
-  SnackbarsProvider: 'providers',
-}
 
 const rules = {
   meta: {
@@ -121,18 +66,4 @@ const rules = {
   },
 }
 
-// export array of config objects for flexible flat config usage
-export const versaurEnforceSubpathImport = [
-  {
-    plugins: {
-      dimasbaguspm: {
-        rules: {
-          'versaur-enforce-subpath-import': rules,
-        },
-      },
-    },
-    rules: {
-      'dimasbaguspm/versaur-enforce-subpath-import': 'warn',
-    },
-  },
-]
+module.exports = { rules }

--- a/scripts/lint-rules/generate.cjs
+++ b/scripts/lint-rules/generate.cjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+/**
+ * Script to auto-generate symbol-to-subpath mapping for Versaur UI library (CommonJS)
+ * Scans src/{primitive,feedbacks,forms,navigation,layouts,overlays,providers}
+ * index.ts for exported symbols.
+ *
+ * Outputs a JS file with the symbolToSubpath object for use in lint rules or tooling
+ */
+const fs = require('fs')
+const path = require('path')
+
+const ROOT = path.resolve(__dirname, '../../src')
+
+// Automatically detect groups as first-level directories under src
+function getGroups() {
+  return fs
+    .readdirSync(ROOT, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => d.name)
+}
+
+function getExportedSymbols(indexPath) {
+  if (!fs.existsSync(indexPath)) return []
+  const content = fs.readFileSync(indexPath, 'utf8')
+  // Match: export { Foo, Bar } from './button'; or export { Foo } from './foo';
+  const re = /export\s+\{([^}]+)\}\s+from\s+['"][^'"]+['"]/g
+  const symbols = []
+  let match
+  while ((match = re.exec(content))) {
+    const names = match[1]
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)
+    symbols.push(...names)
+  }
+  // Also match: export { Foo };
+  const re2 = /export\s+\{([^}]+)\}\s*;/g
+  while ((match = re2.exec(content))) {
+    const names = match[1]
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)
+    symbols.push(...names)
+  }
+  // Also match: export const Foo = ...
+  const re3 = /export\s+const\s+([A-Z][A-Za-z0-9_]*)/g
+  while ((match = re3.exec(content))) {
+    symbols.push(match[1])
+  }
+  // Also match: export function Foo ...
+  const re4 = /export\s+function\s+([A-Z][A-Za-z0-9_]*)/g
+  while ((match = re4.exec(content))) {
+    symbols.push(match[1])
+  }
+  // Also match: export class Foo ...
+  const re5 = /export\s+class\s+([A-Z][A-Za-z0-9_]*)/g
+  while ((match = re5.exec(content))) {
+    symbols.push(match[1])
+  }
+  return Array.from(new Set(symbols))
+}
+
+function ensureDirSync(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+}
+
+function main() {
+  const symbolToSubpath = {}
+  const GROUPS = getGroups()
+  for (const group of GROUPS) {
+    const groupDir = path.join(ROOT, group)
+    if (!fs.existsSync(groupDir)) continue
+
+    // 1. Scan group-level index.ts
+    const groupIndex = path.join(groupDir, 'index.ts')
+    const groupSymbols = getExportedSymbols(groupIndex)
+
+    for (const symbol of groupSymbols) {
+      symbolToSubpath[symbol] = group
+    }
+
+    // 2. Scan subdirectories as before
+    const subdirs = fs
+      .readdirSync(groupDir, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name)
+
+    for (const subdir of subdirs) {
+      const indexPath = path.join(groupDir, subdir, 'index.ts')
+      const symbols = getExportedSymbols(indexPath)
+
+      for (const symbol of symbols) {
+        symbolToSubpath[symbol] = group
+      }
+    }
+  }
+
+  // Ensure dist/utils directory exists
+  ensureDirSync(__dirname)
+  // Write output file with both symbolToSubpath and the ESLint rule
+  const outPath = path.join(__dirname, '../../dist/utils/enforce-subpath-import.js')
+  const header =
+    '/**\n * Auto-generated symbol-to-subpath mapping and ESLint rule for Versaur\n * Run dist/utils/lint-rules.cjs to update\n */\n'
+  // Load the rule template
+  const rulePath = path.resolve(__dirname, './base-rule.js')
+  let ruleSrc = fs.readFileSync(rulePath, 'utf8')
+  // Remove the module.exports line from the rule template
+  ruleSrc = ruleSrc.replace(/module\.exports\s*=\s*\{\s*rules\s*}\s*;?/g, '')
+  // Compose the output
+  const output = `${header}
+const symbolToSubpath = ${JSON.stringify(symbolToSubpath, null, 2)};
+
+${ruleSrc}
+
+// Compose the config for ESLint Flat config usage
+export const versaurEnforceSubpathImport = [
+  {
+    plugins: {
+      dimasbaguspm: {
+        rules: {
+          'versaur-enforce-subpath-import': rules,
+        },
+      },
+    },
+    rules: {
+      'dimasbaguspm/versaur-enforce-subpath-import': 'warn',
+    },
+  },
+]
+`
+  // Ensure the output file and its parent directories exist
+  const outDir = path.dirname(outPath)
+  ensureDirSync(outDir)
+  if (!fs.existsSync(outPath)) {
+    fs.writeFileSync(outPath, '', 'utf8')
+  }
+  fs.writeFileSync(outPath, output, 'utf8')
+
+  // Format the generated file with Prettier if available
+  try {
+    require('child_process').execSync(`npx prettier --write "${outPath}"`, { stdio: 'inherit' })
+  } catch (e) {
+    console.warn('Prettier not found or failed to format. Skipping formatting.')
+  }
+  console.log('Generated', outPath)
+}
+
+if (require.main === module) {
+  main()
+}

--- a/scripts/post-build.cjs
+++ b/scripts/post-build.cjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+// Script to execute lint-rules/generate.cjs with Node.js
+const { execSync } = require('child_process')
+const path = require('path')
+
+const scriptPath = path.resolve(__dirname, 'lint-rules/generate.cjs')
+
+try {
+  execSync(`node "${scriptPath}"`, { stdio: 'inherit' })
+  console.log('Successfully ran lint-rules/generate.cjs')
+} catch (err) {
+  console.error('Failed to run lint-rules/generate.cjs:', err)
+  process.exit(1)
+}

--- a/src/feedbacks/loading-indicator/index.ts
+++ b/src/feedbacks/loading-indicator/index.ts
@@ -1,1 +1,2 @@
-export * from './loading-indicator'
+export { LoadingIndicator } from './loading-indicator'
+export type * from './types'

--- a/src/forms/chip-single-input/index.ts
+++ b/src/forms/chip-single-input/index.ts
@@ -1,1 +1,2 @@
-// ...existing code...
+export { ChipSingleInput } from './chip-single-input'
+export type * from './types'

--- a/src/forms/price-input/index.ts
+++ b/src/forms/price-input/index.ts
@@ -1,2 +1,2 @@
-export * from './price-input'
+export { PriceInput } from './price-input'
 export type { PriceInputProps } from './types'

--- a/src/forms/switch-input/index.ts
+++ b/src/forms/switch-input/index.ts
@@ -1,3 +1,2 @@
-export * from './switch-input'
-export * from './switch-input.atoms'
-export * from './types'
+export { SwitchInput } from './switch-input'
+export type * from './types'

--- a/src/layouts/page-layout/index.ts
+++ b/src/layouts/page-layout/index.ts
@@ -1,1 +1,2 @@
-export * from './page-layout'
+export { PageLayout } from './page-layout'
+export type * from './types'

--- a/src/overlays/menu/index.ts
+++ b/src/overlays/menu/index.ts
@@ -1,2 +1,2 @@
-export * from './menu'
-export * from './types'
+export { Menu } from './menu'
+export type * from './types'


### PR DESCRIPTION
Introduce a generator script to automatically create symbol-to-subpath mappings for the Versaur UI library. Update the ESLint rule to utilize the generated mappings, ensuring optimal tree-shaking. Adjust file exports to align with the new structure and improve code organization.

Fixes #135