### PR TITLE
fix(bottom-bar): remove font-semibold from active item variant, add select-none class to bottom bar item variants

### DIFF
--- a/src/layouts/bottom-bar/__tests__/__snapshots__/bottom-bar.test.tsx.snap
+++ b/src/layouts/bottom-bar/__tests__/__snapshots__/bottom-bar.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`BottomBar > renders 3 items and matches snapshot 1`] = `
     >
       <div
         aria-current="page"
-        class="flex flex-col items-center justify-center gap-1 px-2 py-1 font-semibold text-primary"
+        class="flex flex-col items-center justify-center gap-1 px-2 py-1 text-primary"
       >
         <svg
           aria-hidden="true"
@@ -119,7 +119,7 @@ exports[`BottomBar > renders 5 items and matches snapshot 1`] = `
     >
       <div
         aria-current="page"
-        class="flex flex-col items-center justify-center gap-1 px-2 py-1 font-semibold text-primary"
+        class="flex flex-col items-center justify-center gap-1 px-2 py-1 text-primary"
       >
         <svg
           aria-hidden="true"

--- a/src/layouts/bottom-bar/__tests__/__snapshots__/bottom-bar.test.tsx.snap
+++ b/src/layouts/bottom-bar/__tests__/__snapshots__/bottom-bar.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`BottomBar > renders 3 items and matches snapshot 1`] = `
     >
       <div
         aria-current="page"
-        class="flex flex-col items-center justify-center gap-1 px-2 py-1 text-primary"
+        class="flex flex-col items-center justify-center gap-1 px-2 py-1 select-none text-primary"
       >
         <svg
           aria-hidden="true"
@@ -41,7 +41,7 @@ exports[`BottomBar > renders 3 items and matches snapshot 1`] = `
         </span>
       </div>
       <div
-        class="flex flex-col items-center justify-center gap-1 px-2 py-1 text-ghost"
+        class="flex flex-col items-center justify-center gap-1 px-2 py-1 select-none text-ghost"
       >
         <svg
           aria-hidden="true"
@@ -72,7 +72,7 @@ exports[`BottomBar > renders 3 items and matches snapshot 1`] = `
         </span>
       </div>
       <div
-        class="flex flex-col items-center justify-center gap-1 px-2 py-1 text-ghost"
+        class="flex flex-col items-center justify-center gap-1 px-2 py-1 select-none text-ghost"
       >
         <svg
           aria-hidden="true"
@@ -119,7 +119,7 @@ exports[`BottomBar > renders 5 items and matches snapshot 1`] = `
     >
       <div
         aria-current="page"
-        class="flex flex-col items-center justify-center gap-1 px-2 py-1 text-primary"
+        class="flex flex-col items-center justify-center gap-1 px-2 py-1 select-none text-primary"
       >
         <svg
           aria-hidden="true"
@@ -148,7 +148,7 @@ exports[`BottomBar > renders 5 items and matches snapshot 1`] = `
         </span>
       </div>
       <div
-        class="flex flex-col items-center justify-center gap-1 px-2 py-1 text-ghost"
+        class="flex flex-col items-center justify-center gap-1 px-2 py-1 select-none text-ghost"
       >
         <svg
           aria-hidden="true"
@@ -179,7 +179,7 @@ exports[`BottomBar > renders 5 items and matches snapshot 1`] = `
         </span>
       </div>
       <div
-        class="flex flex-col items-center justify-center gap-1 px-2 py-1 text-ghost"
+        class="flex flex-col items-center justify-center gap-1 px-2 py-1 select-none text-ghost"
       >
         <button
           aria-disabled="false"
@@ -210,7 +210,7 @@ exports[`BottomBar > renders 5 items and matches snapshot 1`] = `
         </button>
       </div>
       <div
-        class="flex flex-col items-center justify-center gap-1 px-2 py-1 text-ghost"
+        class="flex flex-col items-center justify-center gap-1 px-2 py-1 select-none text-ghost"
       >
         <svg
           aria-hidden="true"
@@ -241,7 +241,7 @@ exports[`BottomBar > renders 5 items and matches snapshot 1`] = `
         </span>
       </div>
       <div
-        class="flex flex-col items-center justify-center gap-1 px-2 py-1 text-ghost"
+        class="flex flex-col items-center justify-center gap-1 px-2 py-1 select-none text-ghost"
       >
         <svg
           aria-hidden="true"

--- a/src/layouts/bottom-bar/helpers.ts
+++ b/src/layouts/bottom-bar/helpers.ts
@@ -25,7 +25,7 @@ export const bottomBarVariants = cva(
 )
 
 export const bottomBarItemVariants = cva(
-  'flex flex-col items-center justify-center gap-1 px-2 py-1',
+  'flex flex-col items-center justify-center gap-1 px-2 py-1 select-none',
   {
     variants: {
       active: {

--- a/src/layouts/bottom-bar/helpers.ts
+++ b/src/layouts/bottom-bar/helpers.ts
@@ -29,7 +29,7 @@ export const bottomBarItemVariants = cva(
   {
     variants: {
       active: {
-        true: 'font-semibold text-primary',
+        true: 'text-primary',
         false: 'text-ghost',
       },
     },


### PR DESCRIPTION
Remove the `font-semibold` class from the active item variant to simplify styling. Add the `select-none` class to bottom bar item variants to prevent text selection.